### PR TITLE
Support new argument to switch the release branch, defaults to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If the package has never been published, the maintainers list will be empty and 
 
 #### Clean Repo Checks
 
-A safe release is a clean release. To check if there are no uncommitted changes, and the user is `master`, run the`dojo-repo-is-clean-check` script. The script will fail with a `1` exit code if the repo is dirty.
+A safe release is a clean release. To check if there are no uncommitted changes, and the user is on the correct branch for release, run the`dojo-repo-is-clean-check` script. The script will fail with a `1` exit code if the repo is dirty.
 
 #### Release
 
@@ -141,6 +141,7 @@ The `dojo-release` script can release a dojo package. The `dist/release` directo
 | `—release` |         | The version to release                   |
 | `—next`    |         | The next version (`package.json` version gets set to this) |
 | `—dry-run` | `false` | Shows the commands that will be run but does not run the commands |
+| `-branch`  | `master`| The branch to perform the release on |
 | `—tag`     | `next`  | The tag to pass to `npm publish`         |
 | `—initial` | `false` | Is this the initial release? If true, the `npm publish` command is run with `—access public` |
 

--- a/src/release.ts
+++ b/src/release.ts
@@ -92,7 +92,7 @@ function getGitRemote(gitBaseRemote: string): string | false {
 
 	console.log(chalk.yellow(`Version: ${releaseVersion}`));
 	console.log(chalk.yellow(`Next Version: ${nextVersion}`));
-	console.log(chalk.yellow(`Next Version: ${releaseBranch}`));
+	console.log(chalk.yellow(`Release Branch: ${releaseBranch}`));
 	console.log(chalk.yellow(`Dry Run: ${dryRun}`));
 	console.log(chalk.yellow(`Push Back: ${pushBack}`));
 	if (gitRemote) {

--- a/src/release.ts
+++ b/src/release.ts
@@ -10,6 +10,7 @@ const {
 	'dry-run': dryRun,
 	'push-back': pushBack,
 	'skip-checks': skipChecks,
+	branch: releaseBranch,
 	tag: releaseTag,
 	initial: isInitialRelease,
 	registry: npmRegistry
@@ -19,6 +20,7 @@ const {
 	'dry-run': boolean;
 	'push-back': boolean;
 	'skip-checks': boolean;
+	branch: string;
 	tag: string;
 	initial: boolean;
 	registry: string | undefined;
@@ -42,6 +44,10 @@ const {
 	.option('push-back', {
 		type: 'boolean',
 		default: false
+	})
+	.option('branch', {
+		type: 'string',
+		default: 'master'
 	})
 	.option('tag', {
 		type: 'string',
@@ -86,6 +92,7 @@ function getGitRemote(gitBaseRemote: string): string | false {
 
 	console.log(chalk.yellow(`Version: ${releaseVersion}`));
 	console.log(chalk.yellow(`Next Version: ${nextVersion}`));
+	console.log(chalk.yellow(`Next Version: ${releaseBranch}`));
 	console.log(chalk.yellow(`Dry Run: ${dryRun}`));
 	console.log(chalk.yellow(`Push Back: ${pushBack}`));
 	if (gitRemote) {
@@ -104,7 +111,7 @@ function getGitRemote(gitBaseRemote: string): string | false {
 		return;
 	}
 
-	if (!skipChecks && (!(await canPublish(isInitialRelease)) || !(await isRepoClean()))) {
+	if (!skipChecks && (!(await canPublish(isInitialRelease)) || !(await isRepoClean(releaseBranch)))) {
 		process.exit(1);
 		return;
 	}
@@ -142,7 +149,7 @@ function getGitRemote(gitBaseRemote: string): string | false {
 	await command('git', ['commit', '-am', `"Update package metadata"`], false);
 
 	if (pushBack && gitRemote) {
-		await command('git', ['push', gitRemote, 'master'], false);
+		await command('git', ['push', gitRemote, releaseBranch], false);
 		await command('git', ['push', gitRemote, '--tags'], false);
 	}
 })();

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -26,7 +26,7 @@ export async function canPublish(isInitialRelease: boolean) {
 	return true;
 }
 
-export async function isRepoClean() {
+export async function isRepoClean(releaseBranch: string) {
 	const gitOutput = (await runAsPromise('git', ['status', '--porcelain'])).trim();
 
 	if (gitOutput) {
@@ -35,8 +35,8 @@ export async function isRepoClean() {
 	}
 
 	const revParse = (await runAsPromise('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).trim();
-	if (revParse !== 'master') {
-		console.log(chalk.red('not on master branch'));
+	if (revParse !== releaseBranch) {
+		console.log(chalk.red(`not on master ${releaseBranch}`));
 		return false;
 	}
 

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -36,7 +36,7 @@ export async function isRepoClean(releaseBranch: string) {
 
 	const revParse = (await runAsPromise('git', ['rev-parse', '--abbrev-ref', 'HEAD'])).trim();
 	if (revParse !== releaseBranch) {
-		console.log(chalk.red(`not on master ${releaseBranch}`));
+		console.log(chalk.red(`not on ${releaseBranch} branch`));
 		return false;
 	}
 


### PR DESCRIPTION
**Type:** feature
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Support new argument to change the release branch, defaults to `master`

Resolves #18 
