### PR TITLE
Target for esm should be es2017, to avoid down emitting async/await etc

### DIFF
--- a/src/tsconfig/esm.json
+++ b/src/tsconfig/esm.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"target": "es2017",
 		"module": "esnext",
+		"downlevelIteration": false,
 		"outDir": "../../../../dist/esm/"
 	}
 }

--- a/src/tsconfig/esm.json
+++ b/src/tsconfig/esm.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./base.json",
 	"compilerOptions": {
-		"target": "es6",
+		"target": "es2017",
 		"module": "esnext",
 		"outDir": "../../../../dist/esm/"
 	}


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**
We are emitting superfluous code for esm at the moment. The target for esm should be at least es2017