### PR TITLE
fix: bump minimum Node version to support ESLint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6'
+- '10'
 env:
   global:
   # Please get your own free key if you want to test yourself


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR bumps the minimum Node version to properly support ESLint.

